### PR TITLE
reocrds -> records

### DIFF
--- a/train.py
+++ b/train.py
@@ -140,7 +140,7 @@ def load_train_data_supervised(tokenizer, args):
     feature_list = []
     df = pd.read_csv(args.train_file, sep=',')
     logger.info("len of train data:{}".format(len(df)))
-    rows = df.to_dict('reocrds')
+    rows = df.to_dict('records')
     # rows = rows[:10000]
     for row in tqdm(rows):
         sent0 = row['sent0']


### PR DESCRIPTION
您好，train.py中函数load_train_data_supervised下df.to_dict的参数reocrds是拼写错误，修改成records或者直接去掉参数即可。给您直接提了个pr，仅修改了该处。